### PR TITLE
TC-17995 - Modify EWS to talk modern auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <!-- Eliminates the file encoding warning. Of course, all of your files
             should probably be UTF-8 nowadays. -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javaLanguage.version>1.8</javaLanguage.version>
+        <javaLanguage.version>1.6</javaLanguage.version>
         <javadoc.doclint.param/>
 
         <!--  Dependencies [BUILD]:  -->

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <groupId>com.microsoft.ews-java-api</groupId>
     <artifactId>ews-java-api-netc</artifactId>
     
-    <version>2.0.1</version>
+    <version>2.0.2</version>
 
     <name>Exchange Web Services Java API</name>
     <description>Exchange Web Services (EWS) Java API</description>
@@ -76,7 +76,7 @@
         <!-- Eliminates the file encoding warning. Of course, all of your files
             should probably be UTF-8 nowadays. -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javaLanguage.version>1.6</javaLanguage.version>
+        <javaLanguage.version>1.8</javaLanguage.version>
         <javadoc.doclint.param/>
 
         <!--  Dependencies [BUILD]:  -->

--- a/src/main/java/microsoft/exchange/webservices/data/credential/BearerTokenCredentials.java
+++ b/src/main/java/microsoft/exchange/webservices/data/credential/BearerTokenCredentials.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License Copyright (c) 2017 Kevin Burek <khb718@g.harvard.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package microsoft.exchange.webservices.data.credential;
+
+import java.util.Map;
+
+import microsoft.exchange.webservices.data.core.request.HttpWebRequest;
+import microsoft.exchange.webservices.data.credential.ExchangeCredentials;
+
+/**
+ * BearerTokenCredentials is used for OAuth2 bearer-token credentials. https://tools.ietf.org/html/rfc6750
+ */
+public class BearerTokenCredentials extends ExchangeCredentials {
+
+    /**
+     * Bearer token format regular expression. https://tools.ietf.org/html/rfc6750#section-2.1
+     */
+    private static final String BEARER_TOKEN_FORMAT_REGEX = "^[-._~+/A-Za-z0-9]+=*$";
+
+    private static final String AUTHORIZATION = "Authorization";
+
+    private static final String BEARER_AUTH_PREAMBLE = "Bearer ";
+
+    /**
+     * The domain.
+     */
+    private String token;
+
+    /**
+     * Gets the token string.
+     *
+     * @return the token.
+     */
+    public String getToken() {
+        return token;
+    }
+
+    /**
+     * Initializes a new instance to specified token string.
+     */
+    public BearerTokenCredentials(String bearerToken) {
+        if (bearerToken == null) {
+            throw new IllegalArgumentException("Bearer token can not be null");
+        }
+
+        this.validateToken(bearerToken);
+
+        this.token = bearerToken;
+    }
+
+    /**
+     * Validates the format of the bearer token, per RFC 6750.
+     *
+     * @param bearerToken The token string.
+     * @throws IllegalArgumentException When the token fails validation.
+     */
+    protected void validateToken(String bearerToken) throws IllegalArgumentException {
+        if (!bearerToken.matches(BEARER_TOKEN_FORMAT_REGEX)) {
+            throw new IllegalArgumentException("Bearer token format is invalid.");
+        }
+    }
+
+    /**
+     * This method is called to apply credential to a service request before the request is made.
+     *
+     * @param request The request.
+     */
+    @Override
+    public void prepareWebRequest(HttpWebRequest request) {
+        Map<String, String> headersMap = request.getHeaders();
+        String bearerValue = BEARER_AUTH_PREAMBLE + token;
+        headersMap.put(AUTHORIZATION, bearerValue);
+        request.setHeaders(headersMap);
+    }
+}

--- a/src/main/java/microsoft/exchange/webservices/data/util/TimeZoneUtils.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/TimeZoneUtils.java
@@ -170,6 +170,7 @@ public final class TimeZoneUtils {
     map.put("America/El_Salvador", "Central America Standard Time");
     map.put("America/Ensenada", "Pacific Standard Time");
     map.put("America/Fort_Wayne", "US Eastern Standard Time");
+    map.put("America/Fort_Nelson", "Mountain Standard Time");
     map.put("America/Fortaleza", "SA Eastern Standard Time");
     map.put("America/Glace_Bay", "Atlantic Standard Time");
     map.put("America/Godthab", "Greenland Standard Time");
@@ -240,6 +241,7 @@ public final class TimeZoneUtils {
     map.put("America/Porto_Acre", "SA Pacific Standard Time");
     map.put("America/Porto_Velho", "SA Western Standard Time");
     map.put("America/Puerto_Rico", "SA Western Standard Time");
+    map.put("America/Punta_Arenas", "Pacific SA Standard Time");
     map.put("America/Rainy_River", "Central Standard Time");
     map.put("America/Rankin_Inlet", "Central Standard Time");
     map.put("America/Recife", "SA Eastern Standard Time");
@@ -464,6 +466,7 @@ public final class TimeZoneUtils {
     map.put("Etc/Zulu", "UTC");
     map.put("Europe/Amsterdam", "W. Europe Standard Time");
     map.put("Europe/Andorra", "W. Europe Standard Time");
+    map.put("Europe/Astrakhan", "Russia Time Zone 3");
     map.put("Europe/Athens", "GTB Standard Time");
     map.put("Europe/Belfast", "GMT Standard Time");
     map.put("Europe/Belgrade", "Central Europe Standard Time");
@@ -483,6 +486,7 @@ public final class TimeZoneUtils {
     map.put("Europe/Istanbul", "Turkey Standard Time");
     map.put("Europe/Jersey", "GMT Standard Time");
     map.put("Europe/Kaliningrad", "Kaliningrad Standard Time");
+    map.put("Europe/Kirov", "Russia Time Zone 3");
     map.put("Europe/Kiev", "FLE Standard Time");
     map.put("Europe/Lisbon", "GMT Standard Time");
     map.put("Europe/Ljubljana", "Central Europe Standard Time");
@@ -504,6 +508,7 @@ public final class TimeZoneUtils {
     map.put("Europe/Samara", "Russia Time Zone 3");
     map.put("Europe/San_Marino", "W. Europe Standard Time");
     map.put("Europe/Sarajevo", "Central European Standard Time");
+    map.put("Europe/Saratov", "Russian Standard Time");
     map.put("Europe/Simferopol", "Russian Standard Time");
     map.put("Europe/Skopje", "Central European Standard Time");
     map.put("Europe/Sofia", "FLE Standard Time");
@@ -511,6 +516,7 @@ public final class TimeZoneUtils {
     map.put("Europe/Tallinn", "FLE Standard Time");
     map.put("Europe/Tirane", "Central Europe Standard Time");
     map.put("Europe/Tiraspol", "GTB Standard Time");
+    map.put("Europe/Ulyanovsk", "Russian Standard Time");
     map.put("Europe/Uzhgorod", "FLE Standard Time");
     map.put("Europe/Vaduz", "W. Europe Standard Time");
     map.put("Europe/Vatican", "W. Europe Standard Time");

--- a/src/test/java/microsoft/exchange/webservices/data/credential/BearerTokenCredentialsTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/credential/BearerTokenCredentialsTest.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License
+ * Copyright (c) 2012 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package microsoft.exchange.webservices.data.credential;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.text.IsEmptyString.isEmptyOrNullString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import microsoft.exchange.webservices.data.core.EwsUtilities;
+import microsoft.exchange.webservices.data.core.EwsXmlReader;
+import microsoft.exchange.webservices.data.core.request.HttpWebRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import javax.xml.stream.events.Characters;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(JUnit4.class) public class BearerTokenCredentialsTest {
+
+  private static final Log LOG = LogFactory.getLog(BearerTokenCredentialsTest.class);
+
+  private static final String SUPERFICIALLY_VALID_TOKEN = "Zm9vLmJhcg==";
+
+  @Mock HttpWebRequest webRequest;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+  }
+  
+  @Test public void testEmitBearerAuthorizationHeader() throws URISyntaxException {
+	        
+	  final String authorizationHeaderKey = "Authorization";
+	        final String bearerTokenPrefix = "Bearer";
+	        final String anyValidToken = SUPERFICIALLY_VALID_TOKEN;
+	        HttpWebRequest mockRequest = mock(HttpWebRequest.class);
+
+	        final ArrayList<HashMap<String, String>> headersContainer = new ArrayList<HashMap<String, String>>();
+	        headersContainer.add(new HashMap<String, String>());
+	        when(mockRequest.getHeaders()).thenReturn(headersContainer.get(0));
+	        doAnswer(new Answer() {
+				@Override
+				public Object answer(InvocationOnMock invocation) throws Throwable {
+		            headersContainer.set(0, (HashMap<String, String>) invocation.getArguments()[0]);
+		            return null;
+				}
+	        }).when(mockRequest).setHeaders((Map<String, String>) any());
+
+	        ExchangeCredentials creds = new BearerTokenCredentials(anyValidToken);
+
+	        creds.prepareWebRequest(mockRequest);
+
+	        Map<String, String> actualHeaders = mockRequest.getHeaders();
+	        Assert.assertTrue("Headers must contain authenticate line.",
+	                        actualHeaders.containsKey(authorizationHeaderKey));
+	        String actualAuthorizationHeader = actualHeaders.get(authorizationHeaderKey);
+	        Assert.assertTrue("Header value must start with " + bearerTokenPrefix, 
+	                        actualAuthorizationHeader.startsWith(bearerTokenPrefix));
+	        Assert.assertTrue("Header value must contain token string.",
+	                        actualAuthorizationHeader.contains(anyValidToken));
+	    }
+
+}


### PR DESCRIPTION
Most of the changes in this PR are from code from a different branch of the main EWS library (also not yet delivered to a formal official build of EWS Java API), so we continue to use our fork there-of.

The change adds the ability to set the bearer token to the EWS requests, which is needed for our Modern auth ability to talk to O365.

Additional changes to support additional time zones that have appeared since our fork was taken.

Review is mainly a formality, as I won't be changing any of the Bearer auth code. The changes for bearer auth come from here: https://github.com/bookaroom/ews-java-api/commit/d6dd97bc1ae9dc9129985d59b238c8f95a42fdc0