### PR TITLE
[TC-21422] Add timeout to HttpWebRequest

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
@@ -648,7 +648,7 @@ public abstract class ServiceRequestBase<T> {
         }
       };
 
-      ExecutorService executorService = SingletonEwsExecutor.getInstance().getExecutorService();;
+      ExecutorService executorService = SingletonEwsExecutor.getInstance().getExecutorService();
 
       Future<Object> future = executorService.submit(task);
       try {

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
@@ -72,6 +72,7 @@ public abstract class ServiceRequestBase<T> {
 
   private static final Log LOG = LogFactory.getLog(ServiceRequestBase.class);
 
+
   /**
    * The service.
    */
@@ -641,12 +642,14 @@ public abstract class ServiceRequestBase<T> {
     final HttpWebRequest request = this.buildEwsHttpWebRequest();
 
     try {
-      ExecutorService executorService = Executors.newCachedThreadPool();
       Callable<Object> task = new Callable<Object>() {
         @Override public Object call() throws Exception{
           return getEwsHttpWebResponse(request);
         }
       };
+
+      ExecutorService executorService = SingletonEwsExecutor.getInstance().getExecutorService();;
+
       Future<Object> future = executorService.submit(task);
       try {
         return (HttpWebRequest) future.get(120, TimeUnit.SECONDS);

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/SingletonEwsExecutor.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/SingletonEwsExecutor.java
@@ -1,0 +1,48 @@
+package microsoft.exchange.webservices.data.core.request;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.annotation.PreDestroy;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class SingletonEwsExecutor {
+    private static SingletonEwsExecutor singletonEwsExecutor = null;
+
+    private final ExecutorService executorService;
+
+    private static final Log log = LogFactory.getLog(SingletonEwsExecutor.class);
+
+    private SingletonEwsExecutor() {
+      executorService = Executors.newCachedThreadPool();
+    }
+
+    public static SingletonEwsExecutor getInstance() {
+      if (singletonEwsExecutor == null) {
+        singletonEwsExecutor = new SingletonEwsExecutor();
+      }
+      return singletonEwsExecutor;
+    }
+
+    public ExecutorService getExecutorService() {
+      return executorService;
+    }
+
+    @PreDestroy
+    public void stop() {
+      try {
+        executorService.shutdown();
+        if (!executorService.awaitTermination(120, TimeUnit.SECONDS)) {
+          executorService.shutdownNow();
+        }
+        if (!executorService.awaitTermination(120, TimeUnit.SECONDS)) {
+          log.error(" Executor did not terminate in a timely fashion");
+        }
+      } catch (InterruptedException ex) {
+        log.error("Exception shutting down executor", ex);
+      }
+    }
+}

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/SingletonEwsExecutor.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/SingletonEwsExecutor.java
@@ -10,7 +10,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class SingletonEwsExecutor {
-    private static SingletonEwsExecutor singletonEwsExecutor = null;
+    private static final SingletonEwsExecutor singletonEwsExecutor = new SingletonEwsExecutor();
 
     private final ExecutorService executorService;
 
@@ -21,9 +21,6 @@ public class SingletonEwsExecutor {
     }
 
     public static SingletonEwsExecutor getInstance() {
-      if (singletonEwsExecutor == null) {
-        singletonEwsExecutor = new SingletonEwsExecutor();
-      }
       return singletonEwsExecutor;
     }
 

--- a/src/test/java/microsoft/exchange/webservices/data/core/SingletonEwsExecutorTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/core/SingletonEwsExecutorTest.java
@@ -1,0 +1,35 @@
+package microsoft.exchange.webservices.data.core;
+
+import microsoft.exchange.webservices.data.core.request.SingletonEwsExecutor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+public class SingletonEwsExecutorTest {
+
+  @Test
+  public void testSingleton() throws Exception{
+    SingletonEwsExecutor singletonEwsExecutor = SingletonEwsExecutor.getInstance();
+    Assert.assertNotNull(singletonEwsExecutor);
+
+    ExecutorService executorService = singletonEwsExecutor.getExecutorService();
+    Assert.assertNotNull(executorService);
+
+    final int testCallback = 0;
+    final int expectedResult = 1;
+
+    Callable<Object> task = new Callable<Object>() {
+      @Override public Object call() throws Exception {
+        return testCallback + 1;
+      }
+    };
+
+    Future<Object> future = executorService.submit(task);
+    int finalResult = (Integer) future.get();
+    Assert.assertEquals(finalResult, expectedResult);
+
+  }
+}


### PR DESCRIPTION
If a polling request gets held up, AbuseMailbox will not poll again until the backend is restarted. A timeout of 2 minutes (can be changed in the future) was added, which will cancel the request and free up the poller to make another request on the next polling schedule.